### PR TITLE
Better CMakeFiles.txt

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -2,6 +2,8 @@ CMAKE_MINIMUM_REQUIRED(VERSION 2.8)
 
 PROJECT(Comparison)
 
+FIND_PACKAGE(PkgConfig)
+
 SET(CMAKE_CXX_COMPILER "/usr/bin/clang++")
 
 MESSAGE(STATUS "Project Name:           ${PROJECT_NAME}")
@@ -12,7 +14,10 @@ MESSAGE(STATUS "Hostname:               ${HOSTNAME}")
 MESSAGE(STATUS "Build Type:             ${CMAKE_BUILD_TYPE}")
 MESSAGE(STATUS "GCC:                    ${CMAKE_CXX_COMPILER}")
 
-include_directories("~/pf/projects" ".")
+PKG_CHECK_MODULES(LIBMICROHTTPD REQUIRED libmicrohttpd>=0.9.0)
+PKG_CHECK_MODULES(SQLITE3 REQUIRED sqlite3>=3.7.0)
+
+include_directories("." "${LIBMICROHTTPD_INCLUDEDIR}" "${SQLITE3_INCLUDEDIR}")
 
 option (BUILD_TESTS "build executables in purpose of unittest." ON)
 
@@ -20,6 +25,7 @@ SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 SET(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS} -DNDEBUG -O3")
 SET(CMAKE_CXX_FLAGS_DEBUG "-O0 -g")
 SET(CMAKE_CXX_FLAGS_GPROF "-O1 -pg")
+SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -L${LIBMICROHTTPD_LIBDIR} -L${SQLITE3_LIBDIR}")
 
 IF(BUILD_TESTS)
   ADD_EXECUTABLE(test core/test.cc)


### PR DESCRIPTION
Hello,
the current implementation of the CMakeFiles for the CPP part of the project doesn't fail if the user didn't install the libraries.
This simple fix should take care of the issue by using the PkgConfig module included in CMake >= 2.0.

I've also added in the minimum version required for the libraries, I had to do it because the default libmicrohttpd installed with Ubuntu 12.04 is too old and doesn't contain all the needed functions.
